### PR TITLE
Change robond-term1 to RoboND

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: robond-term1
+name: RoboND
 channels:
     - https://conda.anaconda.org/menpo
     - conda-forge
@@ -21,4 +21,4 @@ dependencies:
     - imageio=2.1.2
     - pyqt=4.11.4
     - pip:
-        - moviepy
+    - moviepy


### PR DESCRIPTION
Hey there, beta tester here, in the readmes the env is set up as RoboND, and the commands are given as:
`conda env remove -n RoboND`
but here in the yml it's robond-term1, either change that one to RoboND or update the docs.